### PR TITLE
Add Client Identifiers

### DIFF
--- a/Client/Edge/EdgeConnector.cs
+++ b/Client/Edge/EdgeConnector.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.AspNetCore.SignalR.Client;
+using Shared.Features;
+
+namespace Client.Edge
+{
+
+    /// <inheritdoc cref="IEdgeConnector"/>
+    public class EdgeConnector(IConfiguration _configuration) : IEdgeConnector
+    {
+        private HubConnection? _hubConnection;
+
+
+        /// <inheritdoc/>
+        public async Task Connect(string? userId = null)
+        {
+            var edgeUrl = _configuration["OverrideEdgeUrl"];
+            if (string.IsNullOrEmpty(userId))
+                userId = _configuration["DefaultUserId"];
+
+            _hubConnection = new HubConnectionBuilder()
+                .WithUrl(new Uri($"{edgeUrl}/clientHub?userId={userId}"))
+                .Build();
+
+            Subscribe();
+
+            try
+            {
+                await _hubConnection.StartAsync();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task Disconnect()
+        {
+            if (_hubConnection != null)
+                await _hubConnection.DisposeAsync();
+        }
+
+
+        private void Subscribe()
+        {
+            _hubConnection?.On<OnFeaturesUpdatedNotification>("OnFeaturesUpdated", notification =>
+            {
+                Console.WriteLine("Received updated features: ");
+
+                foreach (var feature in notification.Features)
+                    Console.WriteLine($"Feature: {feature.Name}");
+            });
+        }
+    }
+}

--- a/Client/Edge/IEdgeConnector.cs
+++ b/Client/Edge/IEdgeConnector.cs
@@ -1,0 +1,21 @@
+﻿namespace Client.Edge
+{
+    /// <summary>
+    /// Connects to the Edge that will manage this Client's state.
+    /// </summary>
+    public interface IEdgeConnector
+    {
+        /// <summary>
+        /// Initiates the connection.
+        /// </summary>
+        /// <param name="userId">The ID of the connecting user.</param>
+        /// <returns>A Task to await the connection.</returns>
+        Task Connect(string? userId);
+
+        /// <summary>
+        /// Stops and disposes of the connection.
+        /// </summary>
+        /// <returns>A Task to await the disconnection.</returns>
+        Task Disconnect();
+    }
+}

--- a/Client/Pages/Home.razor
+++ b/Client/Pages/Home.razor
@@ -1,9 +1,12 @@
 ﻿@page "/"
+@using Client.Edge
 @using Microsoft.AspNetCore.SignalR.Client
 @using Shared.Features
 @using System.Web
 
+@inject IEdgeConnector EdgeConnector;
 @inject NavigationManager NavigationManager;
+
 
 <PageTitle>Idlenomics</PageTitle>
 
@@ -28,29 +31,7 @@
         var uri = new Uri(NavigationManager.Uri);
         var queryParams = HttpUtility.ParseQueryString(uri.Query);
 
-        // TODO :: Decode the guest param to authenticate with login, get the userId 
-        //          from the login service.
-        var userId = queryParams[GuestParamName];
-
-        HubConnection hubConnection = new HubConnectionBuilder()
-            .WithUrl(new Uri($"https://localhost:7285/clientHub?userId={userId}"))
-            .Build();
-
-        hubConnection.On<OnFeaturesUpdatedNotification>("OnFeaturesUpdated", notification =>
-        {
-            Console.WriteLine("Received updated features: ");
-            foreach (var feature in notification.Features)
-                Console.WriteLine($"Feature: {feature.Name}");
-        });
-
-        try
-        {
-            await hubConnection.StartAsync();
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-        }
+        await EdgeConnector.Connect(queryParams[GuestParamName]);
 
         hasStarted = true;
     }

--- a/Client/Pages/Home.razor
+++ b/Client/Pages/Home.razor
@@ -1,6 +1,9 @@
 ﻿@page "/"
 @using Microsoft.AspNetCore.SignalR.Client
 @using Shared.Features
+@using System.Web
+
+@inject NavigationManager NavigationManager;
 
 <PageTitle>Idlenomics</PageTitle>
 
@@ -16,12 +19,21 @@
 </div>
 
 @code {
+    private const string GuestParamName = "guest";
+
     private bool hasStarted;
 
     private async Task Start()
     {
+        var uri = new Uri(NavigationManager.Uri);
+        var queryParams = HttpUtility.ParseQueryString(uri.Query);
+
+        // TODO :: Decode the guest param to authenticate with login, get the userId 
+        //          from the login service.
+        var userId = queryParams[GuestParamName];
+
         HubConnection hubConnection = new HubConnectionBuilder()
-            .WithUrl(new Uri("https://localhost:7285/clientHub"))
+            .WithUrl(new Uri($"https://localhost:7285/clientHub?userId={userId}"))
             .Build();
 
         hubConnection.On<OnFeaturesUpdatedNotification>("OnFeaturesUpdated", notification =>

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -1,4 +1,5 @@
 using Client;
+using Client.Edge;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
@@ -9,5 +10,11 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => 
     new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+builder.Services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+    .AddJsonFile(builder.HostEnvironment.IsDevelopment() ? 
+        "appsettings.Development.json" : "appsettings.json")
+    .Build());
+builder.Services.AddSingleton<IEdgeConnector, EdgeConnector>();
 
 await builder.Build().RunAsync();

--- a/Client/wwwroot/appsettings.Development.json
+++ b/Client/wwwroot/appsettings.Development.json
@@ -1,0 +1,4 @@
+{
+  "DefaultUserId": "DefaultTestUser",
+  "OverrideEdgeUrl": "https://localhost:7285"
+}

--- a/Edge/ClientHub.cs
+++ b/Edge/ClientHub.cs
@@ -35,10 +35,11 @@ public class ClientHub(IUserManager _userManager, ILogger<ClientHub> _logger) : 
     public override Task OnConnectedAsync()
     {
         var userId = UserId;
-        _logger.LogDebug($"Client connected with user ID: {userId}");
 
         _userManager.RegisterUser(userId);
         _userManager.ConnectUser(userId, Context.ConnectionId);
+
+        _logger.LogDebug($"Client connected with user ID: {userId}");
 
         return base.OnConnectedAsync();
     }
@@ -46,7 +47,10 @@ public class ClientHub(IUserManager _userManager, ILogger<ClientHub> _logger) : 
     /// <inheritdoc/>
     public override Task OnDisconnectedAsync(Exception? exception)
     {
-        _userManager.DisconnectUser(UserId, Context.ConnectionId);
+        var userId = UserId;
+        _userManager.DisconnectUser(userId, Context.ConnectionId);
+
+        _logger.LogDebug($"Client disconnected with user ID: {userId}");
 
         return base.OnDisconnectedAsync(exception);
     }

--- a/Edge/ClientHub.cs
+++ b/Edge/ClientHub.cs
@@ -46,7 +46,7 @@ public class ClientHub(IUserManager _userManager, ILogger<ClientHub> _logger) : 
     /// <inheritdoc/>
     public override Task OnDisconnectedAsync(Exception? exception)
     {
-        _userManager.DisconnectUser("", Context.ConnectionId);
+        _userManager.DisconnectUser(UserId, Context.ConnectionId);
 
         return base.OnDisconnectedAsync(exception);
     }


### PR DESCRIPTION
Resolves #7.

Adds user identifier support to Client and Edge, such that a default user identifier is specified in the Client's `appsettings.json` and can be overridden by a `guest` query parameter in the URL..